### PR TITLE
 modify Snakefile and add option in conf file to run dekupl on ensembl…

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "annotation_type": "gencode",
   "fastq_dir": "data",
   "nb_threads": 8,
   "kmer_length": 31,


### PR DESCRIPTION
Hello, in the past I changed the code of the dekupl-run Snakefile and dekupl-annotation to use it on ensembl official gff/gtf, making possible to run de-kupl on non-human models. My initial tests were based on the zebrafish annotation for example. I tried to make this version with the minimum of modifications and exclusively on dekupl-run. To be brief the genes names and other informations are stored differentially in the fasta and I changed the extraction in consequence. The config file contain now the "annotation_type" that can be "gencode" or "ensembl", it works as an option. Finally the gff file of ensembl don't contain the ENSGXXXXXXXX **.X**  information, so I removed it when the gene reference is extracted form the fasta. Otherwise dekupl-annotation getSwitches.R code will output nothing. DEKUPL-ANNOTATION IS NOT FULLY TESTED WITH THIS VERSION. I'm afraid that i must remove the **.X** information in transcript references too, even if I'm not sure that transcript reference is used in gff management of dekupl-annotation.

ps : it lack a space in annotation download commande, do not accept this modification.