### PR TITLE
Fixing missing snakemake in dockerfile and update singularity doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/TtestFilter
 bin/computeNF
 bin/joinCounts
 dekupl-run.simg
+bin/kallisto
+share/kallisto_linux-v0.43.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ WORKDIR /dekupl
 COPY install_r_packages.R .
 RUN Rscript install_r_packages.R
 
+# Python
+RUN pip install snakemake
+
 COPY bin bin
 COPY share share
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ docker run --rm -v ${PWD}my-config.json:/dekupl/my-config.json -v ${PWD}/data:/d
 
 ### Run dekupl-run with singularity
 ```
-singularity build --sandbox dekupl-run.img docker://transipedia/dekupl-run
+singularity pull docker://transipedia/dekupl-run
+./dekupl-run.simg --configfile my-config.json -jNB_THREADS --resources ram=MAX_MEMORY -p
+```
+OR
+```
+singularity build dekupl-run.img docker://transipedia/dekupl-run
 singularity run ./dekupl-run.img --configfile my-config.json -jNB_THREADS --resources ram=MAX_MEMORY -p
 ```
 You don't need to mount any volumes with singularity, but you must have your config.json and your inputs file in the directory where you are running dekupl-run.


### PR DESCRIPTION
With the previous PR from @jaudoux , we can now have a singularity image that's can be run in read only.
I updated the doc to reflect that (and fixing missing snakemake in docker).