### PR TITLE
make sure `sort` uses specified temp directory, refs #52

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -552,7 +552,7 @@ rule jellyfish_dump:
     exec_time = LOGS + "/{sample}_jellyfishDumpRawCounts_exec_time.log"
   run:
     start_log(log['exec_time'], "jellyfish_dump")
-    shell("{JELLYFISH_DUMP} -c {input} | {SORT} -k 1 -S {resources.ram}M --parallel {threads}| pigz -p {threads} -c > {output}")
+    shell("{JELLYFISH_DUMP} -c {input} | {SORT} -T {TMP_DIR} -k 1 -S {resources.ram}M --parallel {threads}| pigz -p {threads} -c > {output}")
     end_log(log['exec_time'], "jellyfish_dump")
 
 rule join_counts:
@@ -601,7 +601,7 @@ rule ref_transcript_dump:
   resources: ram = MAX_MEM_SORT
   run:
     start_log(log['exec_time'], "ref_transcript_dump")
-    shell("{JELLYFISH_DUMP} -c {input} | {SORT} -k 1 -S {resources.ram}M --parallel {threads}| pigz -p {threads} -c > {output}")
+    shell("{JELLYFISH_DUMP} -c {input} | {SORT} -T {TMP_DIR} -k 1 -S {resources.ram}M --parallel {threads}| pigz -p {threads} -c > {output}")
     end_log(log['exec_time'], "ref_transcript_dump")
 
 # 3.3 Filter counter k-mer that are present in the transcriptome set


### PR DESCRIPTION
See #52.

Additionally I suggest (not in this PR) changing the default value for `TMP_DIR` from `os.getcwd()` to `OUTPUT_DIR/tmp` because:
* the current working directory may not necessarily be on a disk that has lots of space, esp. in the docker usage where only the input and output directories are mounted to the container.
* the user is guaranteed to be aware that the output directory must have lots of space to hold the results.
* input directory could also be considered but it is common to mount input directories in read-only mode onto docker containers to avoid accidental file corruption.