### PR TITLE
seed fixed for shuffle before DESeq2

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Set parameter `lib_type` to *"single"*. You can also specify fragments length (s
 - **transcript_fasta**: The reference transcriptome to be used for masking. By default DEKupl-run uses the human Gencode transcriptome for masking. To change this, add to the config.json file:
 `"transcript_fasta":my_transciptome.fa`
 - **transcript_to_gene**: This is a two column tabulated file, with the transcript ID in the first column and the gene ID in the second column. The file is not mandatory if the FASTA transcriptome is from Gencode, were the gene ID can be extracted from the sequence names in the FASTA. An example of this file can be found here : [tests/gencode.v24.transcripts.head1000.mapping.tsv](tests/gencode.v24.transcripts.head1000.mapping.tsv).
+- **seed**: Fixation of the seed for k-mer differential statistics. By default DEKupl-run fixes the variation due to the statistical method but it could add a quite overhead on the analysis (default: 'fixed'; possible choices are 'fixed' or 'not-fixed). Not useful for Ttest.
 
 ### Configuration for single-end libraries
 

--- a/Snakefile
+++ b/Snakefile
@@ -164,10 +164,8 @@ if DIFF_METHOD == "DESeq2":
     TEST_DIFF_SCRIPT   = BIN_DIR + "/DESeq2_diff_method.R"
 elif DIFF_METHOD == "Ttest":
     TEST_DIFF_SCRIPT   = BIN_DIR + "/Ttest_diff_method.R"
-elif DIFF_METHOD == "limma-voom":
-    TEST_DIFF_SCRIPT   = BIN_DIR + "/limma-voom_diff_method.R"
 else:
-    sys.exit("Invalid value for 'diff_method', possible choices are: 'DESeq2', 'limma-voom' and 'Ttest'")
+    sys.exit("Invalid value for 'diff_method', possible choices are: 'DESeq2' and 'Ttest'")
 
 # AUTOMATICALLY SET GENE DIFF METHOD TO LIMMA-VOOM IF MORE THAN 100 SAMPLES
 if 'gene_diff_method' not in config :

--- a/bin/DESeq2_diff_method.R
+++ b/bin/DESeq2_diff_method.R
@@ -95,8 +95,9 @@ system(paste("rm -f ", output_tmp_chunks, "/*", sep=""))
 system(paste("zcat", kmer_counts, "| head -1 | cut -f2- >", header_kmer_counts))
 
 # SHUFFLE AND SPLIT THE MAIN FILE INTO CHUNKS WITH AUTOINCREMENTED NAMES
-system(paste("zcat", kmer_counts, "| tail -n +2 | shuf | awk -v", paste("chunk_size=", chunk_size,sep=""), "-v", paste("output_tmp_chunks=",output_tmp_chunks,sep=""),
+system(paste("cp",kmer_counts, "tmp_shuff.gz; gunzip tmp_shuff.gz; rm tmp_shuff.gz; zcat", kmer_counts, "| tail -n +2 | shuf --random-source=tmp_shuff  | awk -v", paste("chunk_size=", chunk_size,sep=""), "-v", paste("output_tmp_chunks=",output_tmp_chunks,sep=""),
              "'NR%chunk_size==1{OFS=\"\\t\";x=++i\"_subfile.txt.gz\"}{OFS=\"\";print | \"gzip >\" output_tmp_chunks x}'"))
+system("rm tmp_shuff")
 
 logging("Shuffle and split done")
 

--- a/bin/DESeq2_diff_method.R
+++ b/bin/DESeq2_diff_method.R
@@ -51,7 +51,7 @@ output_log                = args[13]#snakemake@log[[1]]
 # Temporary files
 output_tmp_chunks         = paste(output_tmp,"/tmp_chunks/",sep="")
 output_tmp_DESeq2         = paste(output_tmp,"/tmp_DESeq2/",sep="")
-header_kmer_counts         = paste(output_tmp,"/header_kmer_counts.txt",sep="")
+header_kmer_counts        = paste(output_tmp,"/header_kmer_counts.txt",sep="")
 tmp_concat                = paste(output_tmp,"/tmp_concat.txt",sep="")
 adj_pvalue                = paste(output_tmp,"/adj_pvalue.txt.gz",sep="")
 dataDESeq2All             = paste(output_tmp,"/dataDESeq2All.txt.gz",sep="")
@@ -95,10 +95,9 @@ system(paste("rm -f ", output_tmp_chunks, "/*", sep=""))
 system(paste("zcat", kmer_counts, "| head -1 | cut -f2- >", header_kmer_counts))
 
 # SHUFFLE AND SPLIT THE MAIN FILE INTO CHUNKS WITH AUTOINCREMENTED NAMES
-system(paste("cp",kmer_counts, "tmp_shuff.gz; gunzip tmp_shuff.gz; rm tmp_shuff.gz; zcat", kmer_counts, "| tail -n +2 | shuf --random-source=tmp_shuff  | awk -v", paste("chunk_size=", chunk_size,sep=""), "-v", paste("output_tmp_chunks=",output_tmp_chunks,sep=""),
+system(paste("zcat", kmer_counts, " >tmp_shuff; cat tmp_shuff| tail -n +2 | shuf --random-source=tmp_shuff | awk -v", paste("chunk_size=", chunk_size,sep=""), "-v", paste("output_tmp_chunks=",output_tmp_chunks,sep=""),
              "'NR%chunk_size==1{OFS=\"\\t\";x=++i\"_subfile.txt.gz\"}{OFS=\"\";print | \"gzip >\" output_tmp_chunks x}'"))
 system("rm tmp_shuff")
-
 logging("Shuffle and split done")
 
 nb_line_last_file = nbLineLastFile(output_tmp_chunks)


### PR DESCRIPTION
I had some reproducibility problems with DESeq2 on k-mers. The origin was the shuffle seed on the k-mers table before DESeq2. I propose a solution to fix the seed.
It is based on the number of bytes of the raw-counts.tsv table to keep a maximum of random, but if we run exactly the same dekupl-run, we will have the same results now.