### PR TITLE
Correction_normalized_counts

### DIFF
--- a/bin/limma-voom_ref_transcripts.R
+++ b/bin/limma-voom_ref_transcripts.R
@@ -74,7 +74,7 @@ fit <- eBayes(fit, robust=FALSE)
 
 # writing in a file normalized counts
 # FIXME add back genes with 0 counts
-normalized_counts <- data.frame(id=row.names(v$E),v$E,row.names=NULL)
+normalized_counts <- data.frame(id=row.names(v$E),2^v$E,row.names=NULL)
 write.table(normalized_counts, file=norm_counts, sep="\t", row.names=F, col.names=T, quote=F)
 
 # Write DEGs to differentially_expressed_genes file


### PR DESCRIPTION
This is a correction of normalized_counts of genes from limma-voom.
Initially, it returned the log(cpm): v$E
Now it return cpm: 2^v$E

I think it's more relevant,
and this correction is necessary to run Switch in Dekupl-annot:
Switch makes log(normalized_count).
If normalized_counts = log(cpm), it could be <0
so log(normalized_count) = log(<0) and return an error.