### PR TITLE
Correction of contrast in DESeq2 and Limma-voom

### DIFF
--- a/bin/DESeq2_diff_method.R
+++ b/bin/DESeq2_diff_method.R
@@ -188,7 +188,7 @@ invisible(foreach(i=1:length(lst_files)) %dopar% {
                              })
 
             dds <- nbinomWaldTest(dds)
-            resDESeq2 <- results(dds, pAdjustMethod = "none")
+            resDESeq2 <- results(dds, pAdjustMethod = "none", contrast = c("condition",conditionB,conditionA))
 
             #COLLECT COUNTS
             NormCount<- as.data.frame(counts(dds, normalized=TRUE))


### PR DESCRIPTION
I found a problem with DESeq2 for k-mers and limma-voom for genes.
We don't specify what is the control condition and the condition to test, so R takes them in alphabetical order and the condition with the name closest to A becomes the control (which in my case, reverses all the logFoldChange in the results).
This problem had to be observed for the differential analysis of genes with DESeq2 because the contrast is specified to correct that.
I propose a correction for the differential analysis of k-mers with DESeq2 similar to the contrast for DESeq2 genes. And for Limma-voom genes, I propose to use the specific contrast system of this method (with design and contrast matrix).